### PR TITLE
docs: add region configuration note for SageMaker deployment

### DIFF
--- a/guides/2_sagemaker.md
+++ b/guides/2_sagemaker.md
@@ -51,6 +51,16 @@ Edit `terraform.tfvars` and set your AWS region (should match your DEFAULT_AWS_R
 aws_region = "us-east-1"  # Use your DEFAULT_AWS_REGION from .env
 ```
 
+⚠️ **Important for non-US-East-1 regions**:
+If you're deploying to a region other than `us-east-1`, you also need to update the SageMaker image URI in `variables.tf`:
+
+1. Open `terraform/2_sagemaker/variables.tf`
+2. On line 9, find the `sagemaker_image_uri` default value
+3. Replace `us-east-1` with your region (e.g., `ap-southeast-2`)
+4. The line should look like: `"763104351884.dkr.ecr.YOUR-REGION.amazonaws.com/huggingface-pytorch-inference:1.13.1-transformers4.26.0-cpu-py39-ubuntu20.04"`
+
+This is necessary because AWS doesn't allow cross-region ECR image pulls.
+
 ## Step 2: Deploy with Terraform
 
 Now let's deploy the SageMaker infrastructure. With the HuggingFace approach, there's no need to prepare model artifacts - the model will be downloaded automatically from HuggingFace Hub!


### PR DESCRIPTION
## Problem

Students deploying to regions other than `us-east-1` may encounter a **cross-region ECR error** during the SageMaker deployment step.
This happens because the `sagemaker_image_uri` variable in `terraform/2_sagemaker/variables.tf` has a hardcoded `us-east-1` in its default value.

**Error message:**

```
ValidationException: Region of "763104351884.dkr.ecr.us-east-1.amazonaws.com/..."
does not match expected region of ap-southeast-2.
Cross region ECR image pulls are not allowed.
```

---

## Solution

Added a clear **note and warning** in **Guide 2 (Step 1)**, right after the `terraform.tfvars` configuration section, to help students update the region in `variables.tf` before running `terraform apply`.

The note includes:

* ⚠️ **Warning icon** for better visibility
* File and line reference (`variables.tf`, line 9)
* Simple, step-by-step instructions
* Example using another region (`ap-southeast-2`)
* A short explanation of why this update is necessary

---

## Testing

Verified in the **`ap-southeast-2`** region — following these new instructions successfully prevents the deployment error.

---

## Impact

* 🧩 **Non-breaking change** — documentation only
* Reduces confusion and failed deployments for students outside `us-east-1`
* Improves learning flow in **Guide 2**
* Can be complemented later with a code-level fix for full region-agnostic support
