### PR TITLE
Fix undefined variable in Guide 8 and align logging example with Planner implementation

### DIFF
--- a/backend/planner/lambda_handler.py
+++ b/backend/planner/lambda_handler.py
@@ -147,12 +147,20 @@ def lambda_handler(event, context):
 
 # For local testing
 if __name__ == "__main__":
-    # Create a test job first
-    test_user_id = "test_user"
+    # Define a test user
+    test_user_id = "test_user_planner_local"
+
+    # Ensure the test user exists before creating a job
+    from src.schemas import UserCreate, JobCreate
     
-    # Create test job
-    from src.schemas import JobCreate
-    
+    user = db.users.find_by_clerk_id(test_user_id)
+    if not user:
+        print(f"Creating test user: {test_user_id}")
+        user_create = UserCreate(clerk_user_id=test_user_id, display_name="Test Planner User")
+        db.users.create(user_create.model_dump(), returning='clerk_user_id')
+
+    # Create a test job
+    print("Creating test job...")
     job_create = JobCreate(
         clerk_user_id=test_user_id,
         job_type='portfolio_analysis',
@@ -162,8 +170,8 @@ if __name__ == "__main__":
         }
     )
     
-    job = db.jobs.create(job_create)
-    job_id = job['id']
+    job = db.jobs.create(job_create.model_dump())
+    job_id = job
     
     print(f"Created test job: {job_id}")
     


### PR DESCRIPTION
## Summary

- **Guide Fix**:
  - Refreshes the monitoring guidance to reflect the actual logging pattern from backend/planner/lambda_handler.py — including fetching the job for user_id, and emitting structured PLANNER_STARTED, AGENT_INVOKED, and PLANNER_COMPLETED events — clarifying where these calls belong so students can mirror the production setup accurately.
  - Corrects the example in guides/8_enterprise.md (line 325) by replacing `details={"accounts": len(accounts)}` with a defined field (user_id) to eliminate the undefined variable.



- **Code Fix** (Planner Local Test Harness):
  - Updates the Planner module’s local test harness to seed a Clerk user before job creation, satisfying the clerk_user_id → users.clerk_user_id foreign-key constraint.
  - Uses .model_dump() results when persisting JobCreate, preventing both the foreign-key violation and the AttributeError caused by passing a raw Pydantic model into db.jobs.create.

## Reasoning

These changes make the examples self-contained, reproducible, and production-consistent:
- The Guide 8 snippet previously used undefined variables, which could confuse learners and lead to runtime errors.
- The revised code mirrors the correct backend implementation, demonstrating proper event logging and CloudWatch verification workflow.
- The test harness fix ensures that the local test path in lambda_handler.py runs cleanly without schema or model errors.

## Verification
- Local test run succeeds after the update:

```bash
$ uv run lambda_handler.py
Creating test job...
Created test job: 8fa22941-34cb-494f-99a0-3772cdec5160
22:35:34 - LiteLLM:INFO: utils.py:3363 -
LiteLLM completion() model= amazon.nova-pro-v1:0; provider = bedrock
{
  "statusCode": 200,
  "body": "{\"success\": true, \"message\": \"Analysis completed for job 8fa22941-34cb-494f-99a0-3772cdec5160\"}"
}
```

- Logs verified in CloudWatch:
PLANNER_STARTED → AGENT_INVOKED → PLANNER_COMPLETED

## Attribution

Thanks to @ed-donner for reviewing and confirming the correction.