### PR TITLE
Update RDS engine version from 15.4 to 15.12

### DIFF
--- a/terraform/5_database/main.tf
+++ b/terraform/5_database/main.tf
@@ -111,7 +111,7 @@ resource "aws_rds_cluster" "aurora" {
   cluster_identifier     = "alex-aurora-cluster"
   engine                 = "aurora-postgresql"
   engine_mode            = "provisioned"
-  engine_version         = "15.4"
+  engine_version         = "15.12"
   database_name          = "alex"
   master_username        = "alexadmin"
   master_password        = random_password.db_password.result


### PR DESCRIPTION
AWS deprecated Aurora PostgreSQL 15.4.
Keeping the same major version for minimal impact.