### PR TITLE
Modified main.tf for AWS region workaround

### DIFF
--- a/terraform/6_agents/main.tf
+++ b/terraform/6_agents/main.tf
@@ -169,9 +169,10 @@ resource "aws_iam_role_policy" "lambda_agents_policy" {
           "bedrock:InvokeModel",
           "bedrock:InvokeModelWithResponseStream"
         ]
+        # Replaced ${var.bedrock_region} with * for Bedrock region workaround
         Resource = [
-          "arn:aws:bedrock:${var.bedrock_region}::foundation-model/*",
-          "arn:aws:bedrock:${var.bedrock_region}:*:inference-profile/*"
+          "arn:aws:bedrock:*::foundation-model/*",
+          "arn:aws:bedrock:*:*:inference-profile/*"
         ]
       }
     ]


### PR DESCRIPTION
Modified lines 173 and 174 of /alex/terraform/6_agents/main.tf.  Replaced "${var.bedrock_region}" with "*"
Changed:
          "arn:aws:bedrock:${var.bedrock_region}::foundation-model/*",
          "arn:aws:bedrock:${var.bedrock_region}:*:inference-profile/*"
To:
          "arn:aws:bedrock:*::foundation-model/*",
          "arn:aws:bedrock:*:*:inference-profile/*"

This change is to workaround an issue with Bedrock using serverless models in a different region than the specified region.  The change provides all agents with access to Bedrock models in all regions.