### PR TITLE
Bootcamp(Ransford) fix: missing required field text

### DIFF
--- a/terraform/3_ingestion/outputs.tf
+++ b/terraform/3_ingestion/outputs.tf
@@ -39,6 +39,6 @@ output "setup_instructions" {
     curl -X POST ${aws_api_gateway_stage.api.invoke_url}/ingest \
       -H "x-api-key: <your-api-key>" \
       -H "Content-Type: application/json" \
-      -d '{"content": "Test document", "metadata": {"source": "test"}}'
+      -d '{"text": "Test document", "metadata": {"source": "test"}}'
   EOT
 }


### PR DESCRIPTION
<img width="731" height="120" alt="alex terraform 3_ingest" src="https://github.com/user-attachments/assets/d1fef924-6d9e-4de9-bfe0-26f5f521721e" />
