### PR TITLE
Retain previous share prices on DB when polygon eod prices unavailable

### DIFF
--- a/backend/planner/market.py
+++ b/backend/planner/market.py
@@ -73,15 +73,24 @@ def update_prices_for_symbols(symbols: Set[str], db) -> None:
     for symbol in symbols_list:
         try:
             price = get_share_price(symbol)
-            if price > 0:
+            if price is not None:
                 price_map[symbol] = price
                 logger.info(f"Market: Retrieved {symbol} price: ${price:.2f}")
             else:
-                logger.warning(f"Market: No price available for {symbol}")
+                logger.warning(f"Market: No price available for {symbol}; "
+                "retaining previous price")
         except Exception as e:
             logger.warning(f"Market: Could not fetch price for {symbol}: {e}")
 
     logger.info(f"Market: Retrieved prices for {len(price_map)}/{len(symbols_list)} symbols")
+
+    # 🚨 If no prices were retrieved at all, skip DB updates entirely
+    if not price_map:
+        logger.warning(
+            "Market: No prices retrieved for any symbols; "
+            "skipping price update and retaining previous prices"
+        )
+        return
 
     # Update database with fetched prices
     for symbol, price in price_map.items():

--- a/backend/planner/prices.py
+++ b/backend/planner/prices.py
@@ -1,10 +1,11 @@
 from polygon import RESTClient
 from dotenv import load_dotenv
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 import random
 from functools import lru_cache
 from datetime import timezone
+from typing import Optional
 
 load_dotenv(override=True)
 
@@ -37,10 +38,10 @@ def get_market_for_prior_date(today):
     return market_data
 
 
-def get_share_price_polygon_eod(symbol) -> float:
+def get_share_price_polygon_eod(symbol) -> Optional[float]:
     today = datetime.now().date().strftime("%Y-%m-%d")
     market_data = get_market_for_prior_date(today)
-    return market_data.get(symbol, 0.0)
+    return market_data.get(symbol)
 
 
 def get_share_price_polygon_min(symbol) -> float:
@@ -49,17 +50,17 @@ def get_share_price_polygon_min(symbol) -> float:
     return result.min.close or result.prev_day.close
 
 
-def get_share_price_polygon(symbol) -> float:
+def get_share_price_polygon(symbol) -> Optional[float]:
     if is_paid_polygon:
         return get_share_price_polygon_min(symbol)
     else:
         return get_share_price_polygon_eod(symbol)
 
 
-def get_share_price(symbol) -> float:
+def get_share_price(symbol) -> Optional[float]:
     if polygon_api_key:
         try:
             return get_share_price_polygon(symbol)
         except Exception as e:
-            print(f"Was not able to use the polygon API due to {e}; using a random number")
-    return float(random.randint(1, 100))
+            print(f"Was not able to use the polygon API due to {e}; ")
+    return None


### PR DESCRIPTION
Changes to market.py and prices.py such that if no market prices are available (holidays/weekends), skip updating it and keep the last known price for the symbol

market.py → skips update when price is not available (None is returned) and preserves last known prices when markets are closed on holidays/weekends. Provides improved observability when no price is available

prices.py → Change price functions to return Optional[float]. Return None if price is not available
