### PR TITLE
Make SageMaker image URI region-agnostic

### DIFF
--- a/terraform/2_sagemaker/main.tf
+++ b/terraform/2_sagemaker/main.tf
@@ -48,7 +48,7 @@ resource "aws_sagemaker_model" "embedding_model" {
   execution_role_arn = aws_iam_role.sagemaker_role.arn
 
   primary_container {
-    image = var.sagemaker_image_uri
+    image = "763104351884.dkr.ecr.${var.aws_region}.amazonaws.com/huggingface-pytorch-inference:1.13.1-transformers4.26.0-cpu-py39-ubuntu20.04"
     environment = {
       HF_MODEL_ID = var.embedding_model_name
       HF_TASK     = "feature-extraction"

--- a/terraform/2_sagemaker/variables.tf
+++ b/terraform/2_sagemaker/variables.tf
@@ -6,7 +6,7 @@ variable "aws_region" {
 variable "sagemaker_image_uri" {
   description = "URI of the SageMaker container image"
   type        = string
-  default     = "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-inference:1.13.1-transformers4.26.0-cpu-py39-ubuntu20.04"
+  default     = "763104351884.dkr.ecr.${var.aws_region}.amazonaws.com/huggingface-pytorch-inference:1.13.1-transformers4.26.0-cpu-py39-ubuntu20.04"
 }
 
 variable "embedding_model_name" {

--- a/terraform/2_sagemaker/variables.tf
+++ b/terraform/2_sagemaker/variables.tf
@@ -6,7 +6,6 @@ variable "aws_region" {
 variable "sagemaker_image_uri" {
   description = "URI of the SageMaker container image"
   type        = string
-  default     = "763104351884.dkr.ecr.${var.aws_region}.amazonaws.com/huggingface-pytorch-inference:1.13.1-transformers4.26.0-cpu-py39-ubuntu20.04"
 }
 
 variable "embedding_model_name" {


### PR DESCRIPTION
This PR addresses the cross-region deployment issue where SageMaker model creation fails if the provider region is not us-east-1.

Changes:

Modified main.tf in the aws_sagemaker_model resource.

Replaced the static region part of the ECR URI with ${var.aws_region}.

Why this is better: Users can now deploy this project in any AWS region (e.g., eu-central-1, us-west-2) without having to manually find and update the Deep Learning Container URI for their specific region. It makes the infrastructure-as-code more robust and portable.

Verified the fix by deploying in eu-central-1 and successfully invoking the endpoint to receive embeddings.

Fixes #30