### PR TITLE
Fix migrate.py references to run_migrations.py

### DIFF
--- a/backend/database/test_data_api.py
+++ b/backend/database/test_data_api.py
@@ -209,7 +209,7 @@ def test_data_api(cluster_arn, secret_arn, region):
     print("\n" + "=" * 50)
     print("✅ Data API is working correctly!")
     print("\n📝 Next steps:")
-    print("1. Run migrations to create tables: uv run migrate.py")
+    print("1. Run migrations to create tables: uv run run_migrations.py")
     print("2. Load seed data: uv run seed_data.py")
     print("3. Test the database package: uv run test_db.py")
     

--- a/terraform/5_database/outputs.tf
+++ b/terraform/5_database/outputs.tf
@@ -52,7 +52,7 @@ output "setup_instructions" {
     
     To set up the database schema:
     cd backend/database
-    uv run migrate.py
+    uv run run_migrations.py
     
     To load sample data:
     uv run reset_db.py --with-test-data


### PR DESCRIPTION
The migration script is named `run_migrations.py`, not `migrate.py`. Fixes references in `test_data_api.py` output and `terraform/5_database/outputs.tf` instructions.