### PR TITLE
fix: add missing symbols to DB before inserting positions

### DIFF
--- a/backend/test_multiple_accounts.py
+++ b/backend/test_multiple_accounts.py
@@ -37,7 +37,7 @@ def test_multiple_accounts():
     print(f'\n✅ Created test user: {test_user_id}')
     
     # Ensure instruments exist
-    instruments = ["SPY", "BND", "VTI", "VXUS", "QQQ", "IWM", "EFA", "AGG", "VNQ", "GLD"]
+    instruments = ["SPY", "BND", "VTI", "VXUS", "QQQ", "IWM", "EFA", "AGG", "VNQ", "GLD", "TSLA", "ARKK"]
     for i, symbol in enumerate(instruments):
         existing = db.instruments.find_by_symbol(symbol)
         if not existing:


### PR DESCRIPTION
## Summary
  - Add the missing `TSLA` and `ARKK` symbols to `backend/test_multiple_accounts.py`
  - Fix the multiple-accounts test setup so all referenced instruments exist in the database
  
 ## Why
  The test referenced symbols that were missing from the DB setup, which caused the test to fail with a foreign key error when creating holdings.