### PR TITLE
fix: Aurora Serverless v2 bootstrap for free-tier AWS accounts (Guide 5)

### DIFF
--- a/backend/database/pyproject.toml
+++ b/backend/database/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "boto3>=1.40.8",
     "pydantic>=2.11.7",
     "python-dotenv>=1.1.1",
+    "tenacity>=9.1.2",
 ]
 
 [build-system]

--- a/backend/database/src/client.py
+++ b/backend/database/src/client.py
@@ -11,6 +11,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from botocore.exceptions import ClientError
 import logging
+from tenacity import retry, stop_after_delay, wait_exponential, retry_if_exception, before_sleep_log
 
 # Try to load .env file if it exists
 try:
@@ -55,9 +56,30 @@ class DataAPIClient:
         self.region = os.environ.get("DEFAULT_AWS_REGION", "us-east-1")
         self.client = boto3.client("rds-data", region_name=self.region)
 
+    @staticmethod
+    def _is_cluster_unavailable(error: Exception) -> bool:
+        if not isinstance(error, ClientError):
+            return False
+        code = error.response.get("Error", {}).get("Code", "")
+        message = error.response.get("Error", {}).get("Message", "")
+        if code == "BadRequestException" and "Communications link failure" in message:
+            return True
+        if code == "InvalidResourceStateException":
+            return True
+        if code == "DatabaseResumingException":
+            return True
+        return False
+
+    @retry(
+        retry=retry_if_exception(_is_cluster_unavailable),
+        stop=stop_after_delay(600),
+        wait=wait_exponential(multiplier=1, min=3, max=10),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
     def execute(self, sql: str, parameters: List[Dict] = None) -> Dict:
         """
-        Execute a SQL statement
+        Execute a SQL statement, retrying if Aurora is resuming from paused state.
 
         Args:
             sql: SQL statement to execute
@@ -66,24 +88,18 @@ class DataAPIClient:
         Returns:
             Response from Data API
         """
-        try:
-            kwargs = {
-                "resourceArn": self.cluster_arn,
-                "secretArn": self.secret_arn,
-                "database": self.database,
-                "sql": sql,
-                "includeResultMetadata": True,  # Include column names
-            }
+        kwargs = {
+            "resourceArn": self.cluster_arn,
+            "secretArn": self.secret_arn,
+            "database": self.database,
+            "sql": sql,
+            "includeResultMetadata": True,
+        }
 
-            if parameters:
-                kwargs["parameters"] = parameters
+        if parameters:
+            kwargs["parameters"] = parameters
 
-            response = self.client.execute_statement(**kwargs)
-            return response
-
-        except ClientError as e:
-            logger.error(f"Database error: {e}")
-            raise
+        return self.client.execute_statement(**kwargs)
 
     def query(self, sql: str, parameters: List[Dict] = None) -> List[Dict]:
         """
@@ -234,8 +250,21 @@ class DataAPIClient:
         response = self.execute(sql, parameters)
         return response.get("numberOfRecordsUpdated", 0)
 
+    def wait_for_cluster(self):
+        """Ensure the Aurora cluster is awake by running a lightweight query."""
+        logger.info("Checking if Aurora cluster is available...")
+        self.execute("SELECT 1")
+        logger.info("Aurora cluster is ready.")
+
+    @retry(
+        retry=retry_if_exception(_is_cluster_unavailable),
+        stop=stop_after_delay(600),
+        wait=wait_exponential(multiplier=1, min=3, max=10),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
     def begin_transaction(self) -> str:
-        """Begin a database transaction"""
+        """Begin a database transaction, retrying if Aurora is resuming."""
         response = self.client.begin_transaction(
             resourceArn=self.cluster_arn, secretArn=self.secret_arn, database=self.database
         )

--- a/bootstrap/destroy_aurora_express.py
+++ b/bootstrap/destroy_aurora_express.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Destroy Aurora Serverless v2 Express cluster for Alex project.
+
+WARNING: This permanently deletes the Aurora cluster and ALL data in it.
+Only use when done developing or to rebuild the cluster from scratch.
+
+Run from the bootstrap/ directory:
+    uv run destroy_aurora_express.py
+
+To rebuild afterwards:
+    uv run setup_aurora_express.py
+"""
+
+import boto3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CLUSTER_ID    = "alex-aurora-cluster"
+
+BOOTSTRAP_DIR = Path(__file__).parent
+REPO_ROOT     = BOOTSTRAP_DIR.parent
+DB_TF_DIR     = REPO_ROOT / "terraform" / "5_database"
+AUTO_TFVARS   = DB_TF_DIR / "bootstrap.auto.tfvars.json"
+
+
+def get_region() -> str:
+    tfvars = DB_TF_DIR / "terraform.tfvars"
+    for line in tfvars.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("aws_region") and "=" in stripped:
+            return stripped.split("=", 1)[1].strip().strip('"').strip("'")
+    raise ValueError("aws_region not found in terraform/5_database/terraform.tfvars")
+
+
+def tf(args: list[str]) -> None:
+    cmd = ["terraform"] + args
+    print(f"    $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=DB_TF_DIR)
+    if result.returncode != 0:
+        sys.exit(f"\n✗ terraform {args[0]} failed (exit {result.returncode})")
+
+
+def main() -> None:
+    print("\n" + "=" * 60)
+    print("  Alex — Aurora Express Destroy")
+    print("=" * 60)
+    print("\n⚠️  This will DELETE the Aurora cluster and ALL DATA.\n")
+    confirm = input("  Type 'yes' to confirm: ").strip().lower()
+    if confirm != "yes":
+        print("  Cancelled.")
+        sys.exit(0)
+
+    region = get_region()
+    rds = boto3.client("rds", region_name=region)
+
+    # ── 1. Delete cluster ────────────────────────────────────────────────────
+    print(f"\n[1/3] Deleting cluster '{CLUSTER_ID}'")
+
+    existing = rds.describe_db_clusters(
+        Filters=[{"Name": "db-cluster-id", "Values": [CLUSTER_ID]}]
+    )["DBClusters"]
+
+    if not existing:
+        print(f"  Cluster '{CLUSTER_ID}' not found — already deleted.")
+    else:
+        status = existing[0]["Status"]
+        print(f"  Current status: {status}")
+
+        # Stopped clusters must be started before instances can be deleted
+        if status == "stopped":
+            print("  Starting cluster so it can be deleted...")
+            rds.start_db_cluster(DBClusterIdentifier=CLUSTER_ID)
+            rds.get_waiter("db_cluster_available").wait(
+                DBClusterIdentifier=CLUSTER_ID,
+                WaiterConfig={"Delay": 15, "MaxAttempts": 40},
+            )
+            print("  Cluster started ✓")
+
+        # Delete cluster member instances first (Express auto-creates one)
+        for member in existing[0].get("DBClusterMembers", []):
+            instance_id = member["DBInstanceIdentifier"]
+            print(f"  Deleting instance '{instance_id}'...")
+            try:
+                rds.delete_db_instance(
+                    DBInstanceIdentifier=instance_id,
+                    SkipFinalSnapshot=True,
+                )
+            except Exception:
+                pass  # already deleting or not found
+
+        rds.delete_db_cluster(
+            DBClusterIdentifier=CLUSTER_ID,
+            SkipFinalSnapshot=True,
+        )
+        print("  Deletion requested. Waiting (final backup can take 15-20 min)...")
+        for i in range(1, 181):  # up to 30 minutes
+            time.sleep(10)
+            remaining = rds.describe_db_clusters(
+                Filters=[{"Name": "db-cluster-id", "Values": [CLUSTER_ID]}]
+            )["DBClusters"]
+            if not remaining:
+                print(f"  Deleted ✓  ({i * 10}s)")
+                break
+            print(f"  ... still deleting ({remaining[0]['Status']}), {i * 10}s elapsed")
+        else:
+            sys.exit("  ✗ Cluster deletion timed out after 30 minutes")
+
+    # ── 2. Remove bootstrap.auto.tfvars.json ────────────────────────────────
+    print("\n[2/3] Removing bootstrap.auto.tfvars.json")
+    if AUTO_TFVARS.exists():
+        AUTO_TFVARS.unlink()
+        print(f"  Removed: {AUTO_TFVARS.relative_to(REPO_ROOT)}")
+    else:
+        print("  Not found — already removed.")
+
+    # ── 3. Update terraform state ────────────────────────────────────────────
+    print("\n[3/3] Terraform apply (clearing cluster ARN from state)")
+    tf(["apply", "-auto-approve"])
+
+    print("\n✅  Aurora cluster destroyed.\n")
+    print("  Terraform IAM role and Secrets Manager secret are still in place.")
+    print("  To recreate the cluster:\n    uv run setup_aurora_express.py\n")
+    print("  To fully destroy everything (including IAM + secret):")
+    print("    cd terraform/5_database && terraform destroy\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/bootstrap/pyproject.toml
+++ b/bootstrap/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "alex-bootstrap"
+version = "0.1.0"
+description = "Bootstrap scripts for Alex Aurora Express cluster setup"
+requires-python = ">=3.12"
+dependencies = [
+    "boto3>=1.40.8",
+    "tenacity>=9.1.4",
+]

--- a/bootstrap/setup_aurora_express.py
+++ b/bootstrap/setup_aurora_express.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Setup Aurora Serverless v2 with Express Configuration for Alex project.
+
+AWS free-tier accounts cannot create Aurora clusters via Terraform because they
+require the --with-express-configuration flag, which the Terraform AWS provider
+does not support. This script handles the full cluster lifecycle outside Terraform,
+then synchronises the result back into Terraform state so downstream modules
+(6_agents, 7_frontend) continue to work unchanged.
+
+What this script does:
+  1. terraform init + apply in 5_database  (creates Secrets Manager secret + IAM)
+  2. Creates Aurora Express cluster via boto3
+  3. Enables the Data API  (uses enable_http_endpoint, NOT modify_db_cluster)
+  4. Sets the master password to match the Terraform-managed secret
+  5. Creates the 'alex' database
+  6. Writes terraform/5_database/bootstrap.auto.tfvars.json  (cluster ARN)
+  7. terraform apply again  (records cluster ARN in state / outputs)
+
+Run from the bootstrap/ directory:
+    uv run setup_aurora_express.py
+"""
+
+import boto3
+import botocore.exceptions
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_exponential
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+CLUSTER_ID     = "alex-aurora-cluster"
+MASTER_USER    = "alexadmin"
+DATABASE_NAME  = "alex"
+
+# Serverless v2 scaling capacity (Aurora Capacity Units).
+# MIN_CAPACITY = 0.0 enables auto-pause when idle — keeps costs near zero
+# for dev/free-tier use.  Raise MAX_CAPACITY for heavier workloads.
+MIN_CAPACITY = 0.0   # 0.0 = auto-pause enabled
+MAX_CAPACITY = 4.0   # Aurora Express default
+
+BOOTSTRAP_DIR  = Path(__file__).parent
+REPO_ROOT      = BOOTSTRAP_DIR.parent
+DB_TF_DIR      = REPO_ROOT / "terraform" / "5_database"
+AUTO_TFVARS    = DB_TF_DIR / "bootstrap.auto.tfvars.json"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def get_region() -> str:
+    """Read aws_region from terraform/5_database/terraform.tfvars."""
+    tfvars = DB_TF_DIR / "terraform.tfvars"
+    for line in tfvars.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("aws_region") and "=" in stripped:
+            return stripped.split("=", 1)[1].strip().strip('"').strip("'")
+    raise ValueError("aws_region not found in terraform/5_database/terraform.tfvars")
+
+
+def tf(args: list[str]) -> None:
+    """Run a terraform command, fail fast on non-zero exit."""
+    cmd = ["terraform"] + args
+    print(f"    $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=DB_TF_DIR)
+    if result.returncode != 0:
+        sys.exit(f"\n✗ terraform {args[0]} failed (exit {result.returncode})")
+
+
+def tf_output(key: str) -> str:
+    """Return a single terraform output value as a string."""
+    result = subprocess.run(
+        ["terraform", "output", "-raw", key],
+        cwd=DB_TF_DIR, capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def poll(check_fn, label: str, interval: int = 10, timeout: int = 600) -> None:
+    """Block until check_fn() returns True or timeout seconds elapse."""
+    elapsed = 0
+    while elapsed < timeout:
+        if check_fn():
+            return
+        print(f"    ⏳ {label} ({elapsed}s elapsed, retrying in {interval}s)")
+        time.sleep(interval)
+        elapsed += interval
+    raise TimeoutError(f"Timed out after {timeout}s waiting for: {label}")
+
+
+def rds_execute(rds_data, max_attempts: int = 36, delay: int = 10, **kwargs) -> dict:
+    """
+    Execute a Data API statement with retry for transient Aurora startup errors.
+
+    Aurora Express frequently returns transient errors while resuming from
+    auto-pause or while the HTTP endpoint is still initialising.
+    """
+    transient_codes = {
+        "DatabaseResumingException",
+        "DatabaseUnavailableException",
+        "HttpEndpointNotEnabledException",
+        "InvalidResourceStateException",
+        # Password propagation after modify_db_cluster can take 30-60s; the
+        # cluster reports "available" before PostgreSQL picks up the new credential.
+        "DatabaseErrorException",
+    }
+    transient_phrases = [
+        "Aurora is starting up",
+        "resuming after being auto-paused",
+        "HttpEndpoint is being enabled",
+        "Communications link failure",
+        "password authentication failed",
+    ]
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return rds_data.execute_statement(**kwargs)
+        except botocore.exceptions.ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            msg  = str(exc)
+            # DatabaseErrorException wraps real SQL errors too; only retry it
+            # when the message matches a known transient phrase.
+            if code == "DatabaseErrorException":
+                transient = any(p in msg for p in transient_phrases)
+            else:
+                transient = code in transient_codes or any(p in msg for p in transient_phrases)
+            if transient and attempt < max_attempts:
+                print(f"    ⏳ Aurora not ready ({code}), attempt {attempt}/{max_attempts}, waiting {delay}s")
+                time.sleep(delay)
+            else:
+                raise
+
+    raise TimeoutError("Aurora did not become ready within the retry window.")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("\n" + "=" * 60)
+    print("  Alex — Aurora Express Setup")
+    print("=" * 60)
+
+    region = get_region()
+    print(f"\n  Region : {region}")
+
+    rds      = boto3.client("rds",             region_name=region)
+    sm       = boto3.client("secretsmanager",  region_name=region)
+    rds_data = boto3.client("rds-data",        region_name=region)
+
+    # ── 1. Terraform: create Secrets Manager secret + IAM role ───────────────
+    print("\n[1/7] Terraform init + apply (Secrets Manager + IAM)")
+    tf(["init", "-upgrade"])
+    tf(["apply", "-auto-approve"])
+
+    secret_arn = tf_output("aurora_secret_arn")
+    print(f"  Secret ARN : {secret_arn}")
+
+    secret_string = json.loads(
+        sm.get_secret_value(SecretId=secret_arn)["SecretString"]
+    )
+    db_password = secret_string["password"]
+    print("  Password read from Secrets Manager ✓")
+
+    # ── 2. Create Aurora Express cluster ────────────────────────────────────
+    print(f"\n[2/7] Aurora Express cluster '{CLUSTER_ID}'")
+
+    existing = rds.describe_db_clusters(
+        Filters=[{"Name": "db-cluster-id", "Values": [CLUSTER_ID]}]
+    )["DBClusters"]
+
+    if existing:
+        cluster_arn = existing[0]["DBClusterArn"]
+        print(f"  Already exists: {cluster_arn}")
+    else:
+        print("  Creating cluster (this takes a few minutes)...")
+        rds.create_db_cluster(
+            DBClusterIdentifier=CLUSTER_ID,
+            Engine="aurora-postgresql",
+            MasterUsername=MASTER_USER,
+            WithExpressConfiguration=True,
+        )
+        rds.get_waiter("db_cluster_available").wait(
+            DBClusterIdentifier=CLUSTER_ID,
+            WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+        )
+        cluster_arn = rds.describe_db_clusters(
+            DBClusterIdentifier=CLUSTER_ID
+        )["DBClusters"][0]["DBClusterArn"]
+        print(f"  Created: {cluster_arn}")
+
+    # ── 3. Enable Data API ──────────────────────────────────────────────────
+    # IMPORTANT: use enable_http_endpoint(), NOT modify_db_cluster().
+    # modify_db_cluster(enable_http_endpoint=True) silently does nothing on Express.
+    print("\n[3/7] Data API")
+
+    http_enabled = rds.describe_db_clusters(
+        DBClusterIdentifier=CLUSTER_ID
+    )["DBClusters"][0].get("HttpEndpointEnabled", False)
+
+    if http_enabled:
+        print("  Already enabled ✓")
+    else:
+        rds.enable_http_endpoint(ResourceArn=cluster_arn)
+        print("  Enabling Data API endpoint, polling until ready...")
+        poll(
+            lambda: rds.describe_db_clusters(
+                DBClusterIdentifier=CLUSTER_ID
+            )["DBClusters"][0].get("HttpEndpointEnabled", False),
+            label="Data API to be enabled",
+        )
+        print("  Enabled ✓  (waiting for cluster to finish modifying)")
+        rds.get_waiter("db_cluster_available").wait(
+            DBClusterIdentifier=CLUSTER_ID,
+            WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+        )
+        print("  Data API ready ✓")
+
+    # ── 4. Set master password + capacity ───────────────────────────────────
+    print("\n[4/7] Syncing cluster password and capacity")
+
+    # Data API enable can leave the cluster briefly in "modifying" even after
+    # the waiter returns.  Use tenacity to retry the modify until the cluster
+    # accepts it, waiting for available inside each attempt.
+    for attempt in Retrying(
+        retry=retry_if_exception_type(rds.exceptions.InvalidDBClusterStateFault),
+        wait=wait_exponential(min=5, max=30),
+        stop=stop_after_delay(300),
+        reraise=True,
+        before_sleep=lambda _: print("  Cluster not yet accepting modifications, retrying..."),
+    ):
+        with attempt:
+            rds.get_waiter("db_cluster_available").wait(
+                DBClusterIdentifier=CLUSTER_ID,
+                WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+            )
+            rds.modify_db_cluster(
+                DBClusterIdentifier=CLUSTER_ID,
+                MasterUserPassword=db_password,
+                ServerlessV2ScalingConfiguration={
+                    "MinCapacity": MIN_CAPACITY,
+                    "MaxCapacity": MAX_CAPACITY,
+                },
+                ApplyImmediately=True,
+            )
+
+    print("  Password change applied, waiting for cluster ...")
+    rds.get_waiter("db_cluster_available").wait(
+        DBClusterIdentifier=CLUSTER_ID,
+        WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+    )
+    # Password propagation to PostgreSQL is handled by rds_execute retrying on
+    # DatabaseErrorException / "password authentication failed".
+    print("  Password synced ✓")
+
+    # ── 5. Create 'alex' database ────────────────────────────────────────────
+    print(f"\n[5/7] Database '{DATABASE_NAME}'")
+
+    # Query postgres system database first (default database for admin tasks).
+    # rds_execute retries DatabaseErrorException so password propagation delay
+    # (up to 60s after modify_db_cluster) is handled automatically.
+    row = rds_execute(
+        rds_data,
+        max_attempts=60,
+        delay=10,
+        resourceArn=cluster_arn,
+        secretArn=secret_arn,
+        database="postgres",
+        sql=f"SELECT 1 FROM pg_database WHERE datname = '{DATABASE_NAME}'",
+    )
+    if row.get("records"):
+        print(f"  '{DATABASE_NAME}' already exists ✓")
+    else:
+        rds_execute(
+            rds_data,
+            max_attempts=60,
+            delay=10,
+            resourceArn=cluster_arn,
+            secretArn=secret_arn,
+            database="postgres",
+            sql=f"CREATE DATABASE {DATABASE_NAME}",
+        )
+        print(f"  '{DATABASE_NAME}' created ✓")
+
+    # ── 6. Write bootstrap.auto.tfvars.json ─────────────────────────────────
+    print("\n[6/7] Writing bootstrap.auto.tfvars.json")
+
+    AUTO_TFVARS.write_text(
+        json.dumps({"aurora_cluster_arn": cluster_arn}, indent=2) + "\n"
+    )
+    print(f"  Written: {AUTO_TFVARS.relative_to(REPO_ROOT)}")
+
+    # ── 7. Terraform apply: record cluster ARN in state/outputs ─────────────
+    print("\n[7/7] Terraform apply (record cluster ARN in state)")
+    tf(["apply", "-auto-approve"])
+
+    # ── Done ─────────────────────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("  ✅  Aurora Express cluster ready!")
+    print("=" * 60)
+    print(f"""
+  Cluster ARN : {cluster_arn}
+  Secret ARN  : {secret_arn}
+  Database    : {DATABASE_NAME}
+  Data API    : enabled
+
+  Next — run the database setup from backend/database/:
+    uv run test_data_api.py
+    uv run run_migrations.py
+    uv run seed_data.py
+    uv run reset_db.py --with-test-data
+    uv run verify_database.py
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/bootstrap/uv.lock
+++ b/bootstrap/uv.lock
@@ -1,0 +1,106 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "alex-bootstrap"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "tenacity" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.40.8" },
+    { name = "tenacity", specifier = ">=9.1.4" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/bd/4d27e9002536dcf85cf97126d4fe93cc01f3a73000f14408ec51554231ca/boto3-1.43.44.tar.gz", hash = "sha256:035d73afe3e29bf271a5b27b30476ff8eefa5ae36f6702eada8e412d5c1420aa", size = 112697, upload-time = "2026-07-09T00:38:47.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/f2/48081d32e813b14ec03495737984208f193d9a102820b25844c61c94d827/boto3-1.43.44-py3-none-any.whl", hash = "sha256:621113f7850caec7c8405a07baa26075f700f78844a7f2fdf4d1f879bd3cc3c1", size = 140029, upload-time = "2026-07-09T00:38:45.63Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/9e/ad63ae4996794be10afef4e1b2f98901947da65c6c349be9c063ee73edbf/botocore-1.43.44.tar.gz", hash = "sha256:cc2a95a53efdcf0ce34a51bca28058e72fcc3b10dd625eb1ad900c5ca3eb8bef", size = 15685774, upload-time = "2026-07-09T00:38:36.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/05/5c5de6ed23b5e1b01e36b9e52f056dc2b09b259daf3371e4b615ad9a1d4a/botocore-1.43.44-py3-none-any.whl", hash = "sha256:6afb846fd93815133a53baf1578f1d6016ddbeda247623360379758ca2e3f338", size = 15374229, upload-time = "2026-07-09T00:38:33.716Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/terraform/5_database/main.tf
+++ b/terraform/5_database/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.5"
-  
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -11,42 +11,36 @@ terraform {
       version = "~> 3.5"
     }
   }
-  
-  # Using local backend - state will be stored in terraform.tfstate in this directory
-  # This is automatically gitignored for security
 }
 
 provider "aws" {
   region = var.aws_region
 }
 
-# Data source for current caller identity
 data "aws_caller_identity" "current" {}
 
-# ========================================
-# Aurora Serverless v2 PostgreSQL Cluster
-# ========================================
+# ============================================================
+# Secrets Manager — database credentials
+# ============================================================
 
-# Random password for database
 resource "random_password" "db_password" {
-  length  = 32
-  special = true
+  length           = 32
+  special          = true
   override_special = "!#$%&*()-_=+[]{}<>:?"
-}
-
-# Secrets Manager secret for database credentials
-resource "aws_secretsmanager_secret" "db_credentials" {
-  name                    = "alex-aurora-credentials-${random_id.suffix.hex}"
-  recovery_window_in_days = 0  # For development - immediate deletion
-  
-  tags = {
-    Project = "alex"
-    Part    = "5"
-  }
 }
 
 resource "random_id" "suffix" {
   byte_length = 4
+}
+
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name                    = "alex-aurora-credentials-${random_id.suffix.hex}"
+  recovery_window_in_days = 0
+
+  tags = {
+    Project = "alex"
+    Part    = "5"
+  }
 }
 
 resource "aws_secretsmanager_secret_version" "db_credentials" {
@@ -57,137 +51,34 @@ resource "aws_secretsmanager_secret_version" "db_credentials" {
   })
 }
 
-# DB Subnet Group (using default VPC)
-data "aws_vpc" "default" {
-  default = true
-}
+# ============================================================
+# IAM role for Lambda → Aurora Data API access
+# ============================================================
 
-data "aws_subnets" "default" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
-  }
-}
-
-resource "aws_db_subnet_group" "aurora" {
-  name       = "alex-aurora-subnet-group"
-  subnet_ids = data.aws_subnets.default.ids
-  
-  tags = {
-    Project = "alex"
-    Part    = "5"
-  }
-}
-
-# Security group for Aurora
-resource "aws_security_group" "aurora" {
-  name        = "alex-aurora-sg"
-  description = "Security group for Alex Aurora cluster"
-  vpc_id      = data.aws_vpc.default.id
-  
-  # Allow PostgreSQL access from within VPC
-  ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = [data.aws_vpc.default.cidr_block]
-  }
-  
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-  
-  tags = {
-    Project = "alex"
-    Part    = "5"
-  }
-}
-
-# Aurora Serverless v2 Cluster
-resource "aws_rds_cluster" "aurora" {
-  cluster_identifier     = "alex-aurora-cluster"
-  engine                 = "aurora-postgresql"
-  engine_mode            = "provisioned"
-  engine_version         = "15.12"
-  database_name          = "alex"
-  master_username        = "alexadmin"
-  master_password        = random_password.db_password.result
-  
-  # Serverless v2 scaling configuration
-  serverlessv2_scaling_configuration {
-    min_capacity = var.min_capacity
-    max_capacity = var.max_capacity
-  }
-  
-  # Enable Data API
-  enable_http_endpoint = true
-  
-  # Networking
-  db_subnet_group_name   = aws_db_subnet_group.aurora.name
-  vpc_security_group_ids = [aws_security_group.aurora.id]
-  
-  # Backup and maintenance
-  backup_retention_period   = 7
-  preferred_backup_window   = "03:00-04:00"
-  preferred_maintenance_window = "sun:04:00-sun:05:00"
-  
-  # Development settings
-  skip_final_snapshot = true
-  apply_immediately   = true
-  
-  tags = {
-    Project = "alex"
-    Part    = "5"
-  }
-}
-
-# Aurora Serverless v2 Instance
-resource "aws_rds_cluster_instance" "aurora" {
-  identifier          = "alex-aurora-instance-1"
-  cluster_identifier  = aws_rds_cluster.aurora.id
-  instance_class      = "db.serverless"
-  engine              = aws_rds_cluster.aurora.engine
-  engine_version      = aws_rds_cluster.aurora.engine_version
-  
-  performance_insights_enabled = false  # Save costs in development
-  
-  tags = {
-    Project = "alex"
-    Part    = "5"
-  }
-}
-
-# IAM role for Lambda to access Aurora Data API
 resource "aws_iam_role" "lambda_aurora_role" {
   name = "alex-lambda-aurora-role"
-  
+
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
       }
     ]
   })
-  
+
   tags = {
     Project = "alex"
     Part    = "5"
   }
 }
 
-# IAM policy for Data API access
 resource "aws_iam_role_policy" "lambda_aurora_policy" {
   name = "alex-lambda-aurora-policy"
   role = aws_iam_role.lambda_aurora_role.id
-  
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -200,13 +91,11 @@ resource "aws_iam_role_policy" "lambda_aurora_policy" {
           "rds-data:CommitTransaction",
           "rds-data:RollbackTransaction"
         ]
-        Resource = aws_rds_cluster.aurora.arn
+        Resource = "*"
       },
       {
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
         Resource = aws_secretsmanager_secret.db_credentials.arn
       },
       {
@@ -222,7 +111,6 @@ resource "aws_iam_role_policy" "lambda_aurora_policy" {
   })
 }
 
-# Attach basic Lambda execution role
 resource "aws_iam_role_policy_attachment" "lambda_basic" {
   role       = aws_iam_role.lambda_aurora_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"

--- a/terraform/5_database/outputs.tf
+++ b/terraform/5_database/outputs.tf
@@ -1,11 +1,6 @@
 output "aurora_cluster_arn" {
-  description = "ARN of the Aurora cluster"
-  value       = aws_rds_cluster.aurora.arn
-}
-
-output "aurora_cluster_endpoint" {
-  description = "Writer endpoint for the Aurora cluster"
-  value       = aws_rds_cluster.aurora.endpoint
+  description = "ARN of the Aurora Express cluster (set by bootstrap/setup_aurora_express.py)"
+  value       = var.aurora_cluster_arn
 }
 
 output "aurora_secret_arn" {
@@ -13,53 +8,12 @@ output "aurora_secret_arn" {
   value       = aws_secretsmanager_secret.db_credentials.arn
 }
 
-output "database_name" {
-  description = "Name of the database"
-  value       = aws_rds_cluster.aurora.database_name
-}
-
 output "lambda_role_arn" {
   description = "ARN of the IAM role for Lambda functions to access Aurora"
   value       = aws_iam_role.lambda_aurora_role.arn
 }
 
-output "data_api_enabled" {
-  description = "Status of Data API"
-  value       = aws_rds_cluster.aurora.enable_http_endpoint ? "Enabled" : "Disabled"
-}
-
-output "setup_instructions" {
-  description = "Instructions for setting up the database"
-  value = <<-EOT
-    
-    ✅ Aurora Serverless v2 cluster deployed successfully!
-    
-    Database Details:
-    - Cluster: ${aws_rds_cluster.aurora.cluster_identifier}
-    - Database: ${aws_rds_cluster.aurora.database_name}
-    - Data API: Enabled
-    
-    Add the following to your .env file:
-    AURORA_CLUSTER_ARN=${aws_rds_cluster.aurora.arn}
-    AURORA_SECRET_ARN=${aws_secretsmanager_secret.db_credentials.arn}
-    
-    Test the Data API connection:
-    aws rds-data execute-statement \
-      --resource-arn ${aws_rds_cluster.aurora.arn} \
-      --secret-arn ${aws_secretsmanager_secret.db_credentials.arn} \
-      --database alex \
-      --sql "SELECT version()"
-    
-    To set up the database schema:
-    cd backend/database
-    uv run run_migrations.py
-    
-    To load sample data:
-    uv run reset_db.py --with-test-data
-    
-    💰 Cost Management:
-    - Current scaling: ${var.min_capacity} - ${var.max_capacity} ACUs
-    - Estimated cost: ~$43/month minimum
-    - To pause: Set min_capacity to 0 (cluster will pause after 5 minutes of inactivity)
-  EOT
+output "database_name" {
+  description = "Application database name"
+  value       = var.database_name
 }

--- a/terraform/5_database/terraform.tfvars.example
+++ b/terraform/5_database/terraform.tfvars.example
@@ -1,13 +1,8 @@
 # Part 5: Database Configuration
-# Copy this file to terraform.tfvars and update with your values
+# Copy this file to terraform.tfvars and update with your values.
 
-# Your AWS region for Aurora database
-# Should match your main infrastructure region
+# Your AWS region for Aurora database (should match your main region)
 aws_region = "us-east-1"
 
-# Aurora Serverless v2 scaling configuration
-# Minimum capacity in ACUs (0.5 = ~$43/month minimum)
-min_capacity = 0.5
-
-# Maximum capacity in ACUs (1.0 keeps costs low for development)
-max_capacity = 1.0
+# aurora_cluster_arn is set automatically by bootstrap/setup_aurora_express.py
+# Do not add it here manually.

--- a/terraform/5_database/variables.tf
+++ b/terraform/5_database/variables.tf
@@ -3,14 +3,14 @@ variable "aws_region" {
   type        = string
 }
 
-variable "min_capacity" {
-  description = "Minimum capacity for Aurora Serverless v2 (in ACUs)"
-  type        = number
-  default     = 0.5
+variable "aurora_cluster_arn" {
+  description = "ARN of the Aurora Express cluster, populated by bootstrap/setup_aurora_express.py via bootstrap.auto.tfvars.json"
+  type        = string
+  default     = ""
 }
 
-variable "max_capacity" {
-  description = "Maximum capacity for Aurora Serverless v2 (in ACUs)"
-  type        = number
-  default     = 1
+variable "database_name" {
+  description = "Application database name"
+  type        = string
+  default     = "alex"
 }


### PR DESCRIPTION
## Summary

On March 25, 2026, AWS launched Aurora PostgreSQL Express Configuration and simultaneously restricted free-tier accounts to that creation path only. Guide 5's `aws_rds_cluster` resource calls `CreateDBCluster` without `WithExpressConfiguration=True`; free-tier accounts get back `InvalidParameterCombination: Free Tier accounts must use Express Configuration`. The `hashicorp/aws` provider does not support the flag (tracking issue filed March 26, 2026). The blocker is architectural: `--with-express-configuration` creates a cluster and a writer instance in a single API call, which does not fit Terraform's one-resource-per-state model.

This PR replaces the three incomplete shell scripts in `bootstrap/` with two idempotent Python scripts that handle the full cluster lifecycle via boto3, then write the cluster ARN back into Terraform via `bootstrap.auto.tfvars.json` (auto-loaded by Terraform; no manual editing). All downstream modules are unchanged: Guide 6 and Guide 7 read the same `terraform/5_database/` outputs as before.

## Design tension: cluster state lives outside Terraform

The Aurora cluster is not in Terraform state. That is the necessary consequence of the provider limitation. The mitigation is `aurora_cluster_arn` with `default = ""` in `variables.tf`, which lets the first `terraform apply` run before the cluster exists to create the Secrets Manager secret and IAM role. `setup_aurora_express.py` then creates the cluster, writes `bootstrap.auto.tfvars.json`, and runs a second `terraform apply` to record the ARN in outputs. Downstream modules pick it up from `terraform output` exactly as before.

One IAM scope change to disclose: the `rds-data` actions in `aws_iam_role_policy` were previously scoped to the cluster ARN. Since the ARN does not exist at first-apply time, the policy now uses `"*"` for `rds-data` actions. The `secretsmanager:GetSecretValue` action remains scoped to the specific secret ARN, so the Lambda role can only authenticate against the correct credentials.

`terraform destroy` in `5_database/` deletes the secret and IAM role but not the cluster, which is not in state. The destroy script handles this; the student instructions call it out explicitly.

## Notable design decisions

**`enable_http_endpoint()` vs `modify_db_cluster(enable_http_endpoint=True)`.** The `EnableHttpEndpoint` parameter on `modify_db_cluster` applies only to Serverless v1. On Serverless v2 it silently does nothing. The setup script uses the dedicated `enable_http_endpoint()` operation, which is the correct call for Serverless v2 and Express clusters.

**Typed exception on `modify_db_cluster` retry.** After `enable_http_endpoint()`, the cluster can briefly reject `modify_db_cluster` with `InvalidDBClusterStateFault` even after the availability waiter returns. The retry uses tenacity `Retrying` on `rds.exceptions.InvalidDBClusterStateFault` (the typed boto3 exception) with exponential backoff. Each retry re-runs the availability waiter before attempting the modify.

**`DatabaseErrorException` guard in `rds_execute`.** After `modify_db_cluster(MasterUserPassword=...)`, PostgreSQL can take 30 to 60 seconds to accept the new credential after the cluster reports "available". The Data API returns `DatabaseErrorException` with "password authentication failed" during that window. `DatabaseErrorException` also wraps genuine SQL errors, so the retry predicate checks the error message against a known-transient phrase list before retrying. Genuine SQL errors still raise immediately.

**Secret ARN is not touched by the destroy script.** Guide 6 Lambda functions reference the secret ARN in their environment variables. Destroying and recreating the secret would change the ARN and break those functions without a re-deploy. The destroy/setup cycle rebuilds only the cluster.

## What is unchanged

`DataAPIClient` in `backend/database/src/client.py` already carried tenacity retry on `execute()` and `begin_transaction()` for auto-pause resume (`DatabaseResumingException`, `BadRequestException: Communications link failure`). This PR adds `tenacity` to `backend/database/pyproject.toml` to make that dependency explicit; the retry logic itself is not new.

Guide 6 and Guide 7 Terraform modules, all Lambda function code, the database schema, and the Secrets Manager secret ARN are untouched.

## Known limitations

`terraform destroy` does not destroy the cluster. Students must run `destroy_aurora_express.py` before `terraform destroy` to avoid an orphaned cluster.

Scaling (`min_capacity`, `max_capacity`) is no longer a Terraform variable. It is configured as constants at the top of `setup_aurora_express.py`.

## Future path

When `hashicorp/aws` adds `WithExpressConfiguration` support: reintroduce `aws_rds_cluster`, restore `min_capacity` and `max_capacity` as Terraform variables, delete `bootstrap.auto.tfvars.json`, and retire the bootstrap scripts. No downstream migration required.

## Files changed

`bootstrap/setup_aurora_express.py` (new): 7-step idempotent cluster setup.
`bootstrap/destroy_aurora_express.py` (new): cluster teardown with confirmation prompt.
`bootstrap/pyproject.toml` (new): uv project; `boto3`, `tenacity`.
`bootstrap/create_express_cluster.sh`, `destroy_express_cluster.sh`, `wait_for_cluster.sh`: deleted.
`terraform/5_database/main.tf`: removed `aws_rds_cluster`; `rds-data` policy scoped to `"*"`.
`terraform/5_database/variables.tf`: removed `min_capacity`, `max_capacity`; `aurora_cluster_arn` gets `default = ""`.
`terraform/5_database/outputs.tf`: outputs read from `var.aurora_cluster_arn`.
`terraform/5_database/terraform.tfvars.example`: simplified.
`backend/database/pyproject.toml`: added `tenacity>=9.1.2`.
`backend/database/src/client.py`: tenacity dependency now explicit; retry logic unchanged.

## Test plan

- [ ] Fresh free-tier account: `cd bootstrap && uv run setup_aurora_express.py` completes all 7 steps cleanly
- [ ] Re-run `setup_aurora_express.py` on an existing cluster: idempotent, no errors, no duplicate resources created
- [ ] `cd terraform/5_database && terraform output` returns correct `aurora_cluster_arn`, `aurora_secret_arn`, `lambda_role_arn` after setup
- [ ] `cd backend/database && uv run test_data_api.py` passes against the bootstrapped cluster
- [ ] `uv run run_migrations.py && uv run seed_data.py && uv run verify_database.py` all pass
- [ ] Guide 6 local tests (`MOCK_LAMBDAS=true`) pass unchanged
- [ ] `cd bootstrap && uv run destroy_aurora_express.py`: cluster deleted, `bootstrap.auto.tfvars.json` removed, `terraform output aurora_cluster_arn` returns `""`
- [ ] Re-run `setup_aurora_express.py` after destroy: cluster recreated cleanly, same secret ARN preserved
