### PR TITLE
fix: disable BuildKit provenance so Lambda accepts the researcher image

### DIFF
--- a/backend/researcher/deploy.py
+++ b/backend/researcher/deploy.py
@@ -182,6 +182,7 @@ def main():
         [
             "docker",
             "build",
+            "--provenance=false",
             "--platform",
             "linux/amd64",
             "-t",


### PR DESCRIPTION
## Problem

`backend/researcher/deploy.py` builds the researcher image with `docker build`. Since BuildKit v0.10, provenance attestations are attached by default, which wraps the result in an OCI image index (manifest list) rather than a single manifest.

AWS Lambda does not support that format, so `terraform apply` fails right after a successful push:

```
Error: creating Lambda Function (alex-researcher): InvalidParameterValueException:
The image manifest, config or layer media type for the source image
<account>.dkr.ecr.us-east-1.amazonaws.com/alex-researcher:deploy-<tag> is not supported.
```

The build log shows the cause:

```
=> => exporting attestation manifest sha256:4e9bc11506...
=> => exporting manifest list sha256:d7cfa4739074...
```

The image itself is fine — correct `linux/amd64` platform, layers pushed successfully. Only the manifest format is rejected.

## Fix

Pass `--provenance=false` to `docker build`, which produces a single manifest that Lambda accepts.

## Verification

Reproduced and fixed on macOS 15 (Apple Silicon) with OrbStack. After the change, the `exporting attestation manifest` / `exporting manifest list` lines disappear, `terraform apply` creates `aws_lambda_function.researcher` successfully, and the Function URL responds on `/health`.

This affects any student on a recent Docker Desktop, OrbStack, or Colima — the default changed in BuildKit v0.10, so newer installs hit it while older ones do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)